### PR TITLE
Carnyx item test

### DIFF
--- a/dropbot/bot.py
+++ b/dropbot/bot.py
@@ -184,7 +184,6 @@ class DropBot(ClientXMPP):
                         return (i, v)
                 else:
                     if len(types) > 10:
-                        import pdb; pdb.set_trace()
                         return "More than 10 items found, please narrow down what you want."
                     return "Did you mean: {}?".format(
                         ', '.join(types.itervalues())

--- a/dropbot/bot.py
+++ b/dropbot/bot.py
@@ -174,7 +174,7 @@ class DropBot(ClientXMPP):
             if item.strip() == '':
                 return 'Usage: !price <item>'
             if item.lower() == 'plex':
-                item = '30 Day'
+                return (u"29668", u"30 Day Pilot's License Extension (PLEX)")
             types = dict([(i, v) for i, v in self.types.iteritems() if item.lower() in v.lower()])
             if len(types) == 0:
                 return "No items named {} found".format(item)
@@ -184,6 +184,7 @@ class DropBot(ClientXMPP):
                         return (i, v)
                 else:
                     if len(types) > 10:
+                        import pdb; pdb.set_trace()
                         return "More than 10 items found, please narrow down what you want."
                     return "Did you mean: {}?".format(
                         ', '.join(types.itervalues())

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -150,8 +150,11 @@ class DropBotTestCase(TestCase):
     def test_cmd_rageping(self):
         pass
 
-    def test_carnyx_items(self):
+    def test_jackdaw(self):
         """
         The items in the Carnyx release can be found.
         """
         self.assertEqual(self.bot._item_picker("Jackdaw"), (u'34828', u'Jackdaw'))
+
+    def test_carnyx_plex(self):
+        self.assertEqual(self.bot._item_picker("plex"), (u"29668", "30 Day Pilot's License Extension (PLEX)"))

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -149,3 +149,9 @@ class DropBotTestCase(TestCase):
 
     def test_cmd_rageping(self):
         pass
+
+    def test_carnyx_items(self):
+        """
+        The items in the Carnyx release can be found.
+        """
+        self.assertEqual(self.bot._item_picker("Jackdaw"), (u'34828', u'Jackdaw'))


### PR DESCRIPTION
Check that the Jackdaw exists (regression test) and lots of items now have '30 Day' in them so the plex lookup wasn't working.